### PR TITLE
[Dev Intern AI PR] add some comments into the Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby ts=2 sw=2 expandtab :
 
+# Vagrantfile for aiohttp-elasticsearch-s3-logs-handler project
+# This file defines the development environment using Docker containers
+
 # Project configuration
 PROJECT = "aiohttp-elasticsearch-s3-logs-handler"
 ENV["VAGRANT_NO_PARALLEL"] = "yes"
@@ -12,6 +15,7 @@ S3_ENDPOINT = "s3:5000"
 AIOHTTP_PORT = 8000
 
 Vagrant.configure(VAGRANTFILE_VERSION) do |config|
+  # Environment variables shared across containers
 
   environment_variables = {
     # used for 'dev' containers to have same permissions as current user
@@ -35,6 +39,7 @@ Vagrant.configure(VAGRANTFILE_VERSION) do |config|
   }
 
   # S3 container configuration
+  # Uses a custom Docker image for S3 server simulation
   config.vm.define "s3" do |s3|
     s3.vm.provider "docker" do |d|
       d.image = "jean553/docker-s3-server-dev"
@@ -43,6 +48,7 @@ Vagrant.configure(VAGRANTFILE_VERSION) do |config|
   end
 
   # Elasticsearch container configuration
+  # Uses official Elasticsearch Docker image with custom settings
   config.vm.define "elasticsearch" do |app|
     app.vm.provider "docker" do |d|
       d.image = "docker.elastic.co/elasticsearch/elasticsearch:5.4.3"
@@ -60,6 +66,7 @@ Vagrant.configure(VAGRANTFILE_VERSION) do |config|
   end
 
   # Kibana container configuration (part of the ELK stack)
+  # Uses official Kibana Docker image linked to Elasticsearch
   config.vm.define "kibana" do |app|
     app.vm.provider "docker" do |d|
       d.image = "docker.elastic.co/kibana/kibana:5.4.3"
@@ -74,6 +81,7 @@ Vagrant.configure(VAGRANTFILE_VERSION) do |config|
 
   config.ssh.insert_key = true
   # Development environment container configuration
+  # Uses a custom Python development image with SSH access
   config.vm.define "dev", primary: true do |app|
     app.vm.provider "docker" do |d|
       d.image = "allansimon/allan-docker-dev-python"
@@ -85,6 +93,7 @@ Vagrant.configure(VAGRANTFILE_VERSION) do |config|
     end
     app.ssh.username = "vagrant"
 
+    # Ansible provisioning for setting up the development environment
     # Ansible provisioning for development environment
     app.vm.provision "ansible", type: "shell" do |ansible|
       ansible.env = environment_variables


### PR DESCRIPTION
To add some comments to the Vagrantfile, I'll include explanatory comments for key sections. Here's the approach:

1. Add a header comment explaining the purpose of the file
2. Add comments for each major section (project configuration, environment variables, container definitions)
3. Include brief explanations for some of the more complex or important configuration options

Here's the git diff with the added comments:

```diff
diff --git a/Vagrantfile b/Vagrantfile
index 1234567..abcdefg 100644
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby ts=2 sw=2 expandtab :
 
+# Vagrantfile for aiohttp-elasticsearch-s3-logs-handler project
+# This file defines the development environment using Docker containers
+
 # Project configuration
 PROJECT = "aiohttp-elasticsearch-s3-logs-handler"
 ENV["VAGRANT_NO_PARALLEL"] = "yes"
@@ -12,6 +15,7 @@ S3_ENDPOINT = "s3:5000"
 AIOHTTP_PORT = 8000
 
 Vagrant.configure(VAGRANTFILE_VERSION) do |config|
+  # Environment variables shared across containers
 
   environment_variables = {
     # used for 'dev' containers to have same permissions as current user
@@ -36,6 +40,7 @@ Vagrant.configure(VAGRANTFILE_VERSION) do |config|
   }
 
   # S3 container configuration
+  # Uses a custom Docker image for S3 server simulation
   config.vm.define "s3" do |s3|
     s3.vm.provider "docker" do |d|
       d.image = "jean553/docker-s3-server-dev"
@@ -44,6 +49,7 @@ Vagrant.configure(VAGRANTFILE_VERSION) do |config|
   end
 
   # Elasticsearch container configuration
+  # Uses official Elasticsearch Docker image with custom settings
   config.vm.define "elasticsearch" do |app|
     app.vm.provider "docker" do |d|
       d.image = "docker.elastic.co/elasticsearch/elasticsearch:5.4.3"
@@ -61,6 +67,7 @@ Vagrant.configure(VAGRANTFILE_VERSION) do |config|
   end
 
   # Kibana container configuration (part of the ELK stack)
+  # Uses official Kibana Docker image linked to Elasticsearch
   config.vm.define "kibana" do |app|
     app.vm.provider "docker" do |d|
       d.image = "docker.elastic.co/kibana/kibana:5.4.3"
@@ -75,6 +82,7 @@ Vagrant.configure(VAGRANTFILE_VERSION) do |config|
 
   config.ssh.insert_key = true
   # Development environment container configuration
+  # Uses a custom Python development image with SSH access
   config.vm.define "dev", primary: true do |app|
     app.vm.provider "docker" do |d|
       d.image = "allansimon/allan-docker-dev-python"
@@ -86,6 +94,7 @@ Vagrant.configure(VAGRANTFILE_VERSION) do |config|
     end
     app.ssh.username = "vagrant"
 
+    # Ansible provisioning for setting up the development environment
     # Ansible provisioning for development environment
     app.vm.provision "ansible", type: "shell" do |ansible|
       ansible.env = environment_variables
```

This diff adds comments to explain the purpose of the Vagrantfile, the main sections, and some key configuration options. The comments provide context for anyone reading or modifying the file in the future.
