### PR TITLE
[Dev Intern AI PR] add comment to the get logs handler

### DIFF
--- a/logs/get_logs_handler.py
+++ b/logs/get_logs_handler.py
@@ -129,10 +129,12 @@ async def get_logs(
     '''
     Sends back logs according to the given dates range and service.
     '''
+    # Extract request parameters
     service_id = request.match_info.get('id')
     start_date = request.match_info.get('start')
     end_date = request.match_info.get('end')
 
+    # Convert date strings to datetime objects
     start = datetime.strptime(
         start_date,
         API_DATE_FORMAT,
@@ -143,17 +145,20 @@ async def get_logs(
         API_DATE_FORMAT,
     )
 
+    # Fetch initial logs from Elasticsearch
     result = await _get_logs_from_elasticsearch(
         service_id,
         start_date,
         end_date,
     )
 
+    # Prepare the streaming response
     stream = web.StreamResponse()
     stream.content_type = 'application/json'
     await stream.prepare(request)
     stream.write(b'{"logs": [')
 
+    # Process Elasticsearch results
     scroll_id = result['_scroll_id']
     logs = result['hits']['hits']
     elasticsearch_logs_amount = len(logs)
@@ -161,8 +166,8 @@ async def get_logs(
     first_iteration = False if elasticsearch_logs_amount > 0 else True
     first_elasticsearch_scroll = True
 
+    # Stream logs from Elasticsearch
     while elasticsearch_logs_amount > 0:
-
         if not first_elasticsearch_scroll:
             stream.write(b',')
 
@@ -171,6 +176,7 @@ async def get_logs(
             logs,
         )
 
+        # Fetch next batch of logs
         result = await _scroll_logs_from_elasticsearch(
             service_id,
             scroll_id,
@@ -182,12 +188,12 @@ async def get_logs(
 
         first_elasticsearch_scroll = False
 
+    # Check if we need to fetch logs from S3
     now = datetime.now()
     last_snapshot_date = now - timedelta(days=SNAPSHOT_DAYS_FROM_NOW)
     if start <= last_snapshot_date:
-
+        # Initialize S3 client
         s3_index_date = start
-
         s3_session = aiobotocore.get_session()
         s3_client = s3_session.create_client(
             service_name='s3',
@@ -197,8 +203,8 @@ async def get_logs(
             endpoint_url='http://' + S3_ENDPOINT,
         )
 
+        # Fetch and stream logs from S3
         while s3_index_date <= last_snapshot_date:
-
             s3_index = 'data-%s-%04d-%02d-%02d' % (
                 service_id,
                 s3_index_date.year,
@@ -211,18 +217,20 @@ async def get_logs(
             s3_response = None
 
             try:
+                # Attempt to get the S3 object
                 s3_response = await s3_client.get_object(
                     Bucket=S3_BUCKET_NAME,
                     Key=s3_index,
                 )
             except botocore.exceptions.ClientError:
+                # Skip if the object doesn't exist
                 continue
 
+            # Process and stream logs from S3
             s3_stream = s3_response['Body']
             s3_line = await s3_stream.readline()
 
             while(len(s3_line) > 0):
-
                 temp_line = s3_line.decode('utf-8')
                 line_items = json.loads(temp_line)
                 log_date = datetime.strptime(
@@ -230,6 +238,7 @@ async def get_logs(
                     '%Y-%m-%dT%H:%M:%S',
                 )
 
+                # Check if the log is within the requested date range
                 if log_date < start or log_date > end:
                     s3_line = await s3_stream.readline()
                     continue
@@ -247,6 +256,7 @@ async def get_logs(
             s3_stream.close()
         s3_client.close()
 
+    # Close the JSON response
     stream.write(b']}')
 
     return stream


### PR DESCRIPTION
Certainly! I'll add comments to the `get_logs` handler in the `logs/get_logs_handler.py` file to improve its documentation. I'll go through the function and add explanatory comments for the main sections and important operations.

Here's the updated file with added comments:

```vim logs/get_logs_handler.py:**********
'''
Handles GET /logs requests.
'''
import json
import async_timeout
from datetime import datetime, timedelta
from typing import Any

import botocore
import aiobotocore

import aiohttp
from aiohttp import web
from elasticsearch import Elasticsearch

from logs.config import S3_ENDPOINT
from logs.config import S3_BUCKET_NAME
from logs.config import ELASTICSEARCH_HOSTNAME
from logs.config import ELASTICSEARCH_PORT

API_DATE_FORMAT = '%Y-%m-%d-%H-%M-%S'
ELASTICSEARCH_DATE_FORMAT = 'yyyy-MM-dd-HH-mm-ss'
SNAPSHOT_DAYS_FROM_NOW = 10
ELASTICSEARCH_REQUESTS_TIMEOUT_SECONDS = 10
ELASTICSEARCH_MAXIMUM_RESULTS_PER_PAGE = 10
ELASTICSEARCH_SEARCH_CONTEXT_LIFETIME = '1m'  # 1 minute


def _get_log_to_string(log: Any) -> str:
    '''
    Returns a string representation of the given log.
    Convert single quotes to double quotes in order to match with JSON format
    (required for streaming)
    '''
    return str(log['_source']).replace("'", '"')


async def _get_logs_from_elasticsearch(
    service_id: int,
    start_date: str,
    end_date: str,
) -> dict:
    '''
    Coroutine that returns the first page of logs from ES.
    '''
    async with aiohttp.ClientSession() as session:
        with async_timeout.timeout(ELASTICSEARCH_REQUESTS_TIMEOUT_SECONDS):
            async with session.get(
                'http://{}:{}/data-{}-*/_search?scroll={}'.format(
                    ELASTICSEARCH_HOSTNAME,
                    ELASTICSEARCH_PORT,
                    service_id,
                    ELASTICSEARCH_SEARCH_CONTEXT_LIFETIME,
                ),
                json={
                    'size': ELASTICSEARCH_MAXIMUM_RESULTS_PER_PAGE,
                    'query': {
                        'bool': {
                            'must': {
                                'match': {
                                    'service_id': service_id
                                }
                            },
                            'filter': {
                                'range': {
                                    'date': {
                                        'gte': start_date,
                                        'lte': end_date,
                                        'format': ELASTICSEARCH_DATE_FORMAT
                                    }
                                }
                            }
                        }
                    }
                }
            ) as response:
                return await response.json()


async def _scroll_logs_from_elasticsearch(
    service_id: int,
    scroll_id: str,
) -> dict:
    '''
    Scroll the next page of found results from Elasticsearch.
    '''
    # TODO: #123 we use a new session for one request here;
    # if we try to use the same session as before,
    # then not all the logs are returned from ES;
    # we have to investigate how to organize the session(s) here
    async with aiohttp.ClientSession() as session:
        with async_timeout.timeout(ELASTICSEARCH_REQUESTS_TIMEOUT_SECONDS):
            async with session.get(
                'http://{}:{}/_search/scroll'.format(
                    ELASTICSEARCH_HOSTNAME,
                    ELASTICSEARCH_PORT,
                    service_id,
                ),
                json={
                    'scroll': ELASTICSEARCH_SEARCH_CONTEXT_LIFETIME,
                    'scroll_id': scroll_id
                }
            ) as response:
                return await response.json()


def _stream_logs_chunk(
    stream: aiohttp.web_response.StreamResponse,
    logs: list,
):
    '''
    Streams each log one by one to the client.
    '''
    last_log_index = len(logs) - 1

    for counter, log in enumerate(logs):
        line = _get_log_to_string(log)

        if counter != last_log_index:
            line += ','

        stream.write(line.encode())


async def get_logs(
    request: web.Request,
    es_client: Elasticsearch,
):
    '''
    Sends back logs according to the given dates range and service.
    '''
    # Extract request parameters
    service_id = request.match_info.get('id')
    start_date = request.match_info.get('start')
    end_date = request.match_info.get('end')

    # Convert date strings to datetime objects
    start = datetime.strptime(
        start_date,
        API_DATE_FORMAT,
    )

    end = datetime.strptime(
        end_date,
        API_DATE_FORMAT,
    )

    # Fetch initial logs from Elasticsearch
    result = await _get_logs_from_elasticsearch(
        service_id,
        start_date,
        end_date,
    )

    # Prepare the streaming response
    stream = web.StreamResponse()
    stream.content_type = 'application/json'
    await stream.prepare(request)
    stream.write(b'{"logs": [')

    # Process Elasticsearch results
    scroll_id = result['_scroll_id']
    logs = result['hits']['hits']
    elasticsearch_logs_amount = len(logs)

    first_iteration = False if elasticsearch_logs_amount > 0 else True
    first_elasticsearch_scroll = True

    # Stream logs from Elasticsearch
    while elasticsearch_logs_amount > 0:
        if not first_elasticsearch_scroll:
            stream.write(b',')

        _stream_logs_chunk(
            stream,
            logs,
        )

        # Fetch next batch of logs
        result = await _scroll_logs_from_elasticsearch(
            service_id,
            scroll_id,
        )

        scroll_id = result['_scroll_id']
        logs = result['hits']['hits']
        elasticsearch_logs_amount = len(logs)

        first_elasticsearch_scroll = False

    # Check if we need to fetch logs from S3
    now = datetime.now()
    last_snapshot_date = now - timedelta(days=SNAPSHOT_DAYS_FROM_NOW)
    if start <= last_snapshot_date:
        # Initialize S3 client
        s3_index_date = start
        s3_session = aiobotocore.get_session()
        s3_client = s3_session.create_client(
            service_name='s3',
            region_name='',
            aws_secret_access_key='',
            aws_access_key_id='',
            endpoint_url='http://' + S3_ENDPOINT,
        )

        # Fetch and stream logs from S3
        while s3_index_date <= last_snapshot_date:
            s3_index = 'data-%s-%04d-%02d-%02d' % (
                service_id,
                s3_index_date.year,
                s3_index_date.month,
                s3_index_date.day,
            )

            s3_index_date += timedelta(days=1)

            s3_response = None

            try:
                # Attempt to get the S3 object
                s3_response = await s3_client.get_object(
                    Bucket=S3_BUCKET_NAME,
                    Key=s3_index,
                )
            except botocore.exceptions.ClientError:
                # Skip if the object doesn't exist
                continue

            # Process and stream logs from S3
            s3_stream = s3_response['Body']
            s3_line = await s3_stream.readline()

            while(len(s3_line) > 0):
                temp_line = s3_line.decode('utf-8')
                line_items = json.loads(temp_line)
                log_date = datetime.strptime(
                    line_items['date'],
                    '%Y-%m-%dT%H:%M:%S',
                )

                # Check if the log is within the requested date range
                if log_date < start or log_date > end:
                    s3_line = await s3_stream.readline()
                    continue

                line = str(line_items).replace("'", '"')

                if not first_iteration:
                    line = ',' + line
                first_iteration = False

                stream.write(line.encode())

                s3_line = await s3_stream.readline()

            s3_stream.close()
        s3_client.close()

    # Close the JSON response
    stream.write(b']}')

    return stream
```

I've added comments to explain the main sections and important operations in the `get_logs` function. These comments provide a high-level overview of what the function does and how it processes logs from both Elasticsearch and S3. The comments help to clarify the flow of the function and make it easier for other developers to understand and maintain the code.
