### PR TITLE
[Dev Intern AI PR] handle https in the nginx configuration

### DIFF
--- a/build_scripts/nginx.conf
+++ b/build_scripts/nginx.conf
@@ -7,10 +7,27 @@ upstream site {
 server {
     listen 80;
     server_name _ ;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name _ ;
+
+    ssl_certificate /etc/nginx/ssl/nginx.crt;
+    ssl_certificate_key /etc/nginx/ssl/nginx.key;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
 
     location / {
         proxy_pass http://site/;
         proxy_redirect off;
         proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }


### PR DESCRIPTION
I'll modify the nginx configuration to handle HTTPS traffic. This involves adding a new server block for HTTPS, redirecting HTTP to HTTPS, and setting up SSL certificates. Here's the approach:

1. Add a new server block for HTTPS (port 443)
2. Redirect HTTP traffic to HTTPS
3. Configure SSL certificates (using self-signed certificates as placeholders)
4. Update the existing HTTP server block to redirect to HTTPS

Here's the modified nginx configuration:

```vim build_scripts/nginx.conf:**********
upstream site {
    server localhost:8000 fail_timeout=5 max_fails=3 ;
    server localhost:8001 fail_timeout=5 max_fails=3 ;
    server localhost:8002 fail_timeout=5 max_fails=3 ;
}

server {
    listen 80;
    server_name _ ;
    return 301 https://$host$request_uri;
}

server {
    listen 443 ssl;
    server_name _ ;

    ssl_certificate /etc/nginx/ssl/nginx.crt;
    ssl_certificate_key /etc/nginx/ssl/nginx.key;

    ssl_protocols TLSv1.2 TLSv1.3;
    ssl_prefer_server_ciphers on;
    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;

    location / {
        proxy_pass http://site/;
        proxy_redirect off;
        proxy_http_version 1.1;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }
}
```

This configuration does the following:

1. Keeps the existing upstream block unchanged.
2. Modifies the existing HTTP server block to redirect all HTTP traffic to HTTPS.
3. Adds a new HTTPS server block that listens on port 443 with SSL enabled.
4. Configures SSL certificates (you'll need to replace the paths with your actual certificate paths).
5. Sets up secure SSL protocols and ciphers.
6. Updates the location block to include additional proxy headers for better security and logging.

Note that you'll need to generate or obtain SSL certificates and update the paths in the configuration accordingly. The paths provided (`/etc/nginx/ssl/nginx.crt` and `/etc/nginx/ssl/nginx.key`) are placeholders.

Also, remember to reload or restart Nginx after making these changes for them to take effect.
