### PR TITLE
[Dev Intern AI PR] handle https in the nginx configuration; the configuration of the nginx server should handle HTTPs

### DIFF
--- a/build_scripts/nginx.conf
+++ b/build_scripts/nginx.conf
@@ -7,10 +7,27 @@ upstream site {
 server {
     listen 80;
     server_name _ ;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name _ ;
+
+    ssl_certificate /path/to/your/certificate.crt;
+    ssl_certificate_key /path/to/your/certificate.key;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
 
     location / {
         proxy_pass http://site/;
         proxy_redirect off;
         proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
     }
 }


### PR DESCRIPTION
To handle HTTPS in the Nginx configuration, we need to make some modifications to the existing configuration. We'll add SSL certificate configuration, redirect HTTP to HTTPS, and update the server block to listen on port 443 for HTTPS traffic. Here's the updated Nginx configuration:

```vim build_scripts/nginx.conf:**********
upstream site {
    server localhost:8000 fail_timeout=5 max_fails=3 ;
    server localhost:8001 fail_timeout=5 max_fails=3 ;
    server localhost:8002 fail_timeout=5 max_fails=3 ;
}

server {
    listen 80;
    server_name _ ;
    return 301 https://$host$request_uri;
}

server {
    listen 443 ssl;
    server_name _ ;

    ssl_certificate /path/to/your/certificate.crt;
    ssl_certificate_key /path/to/your/certificate.key;

    ssl_protocols TLSv1.2 TLSv1.3;
    ssl_prefer_server_ciphers on;
    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;

    location / {
        proxy_pass http://site/;
        proxy_redirect off;
        proxy_http_version 1.1;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header Host $http_host;
        proxy_set_header X-Real-IP $remote_addr;
    }
}
```

Here's an explanation of the changes made to handle HTTPS:

1. We added a new server block that listens on port 80 (HTTP) and redirects all traffic to HTTPS using a 301 permanent redirect.

2. We modified the existing server block to listen on port 443 with SSL enabled.

3. We added SSL certificate configuration:
   - `ssl_certificate`: Path to your SSL certificate file
   - `ssl_certificate_key`: Path to your SSL certificate key file

4. We added SSL protocol and cipher configurations for better security:
   - `ssl_protocols`: Specifies the SSL/TLS protocols to use
   - `ssl_prefer_server_ciphers`: Tells Nginx to use server ciphers over client ciphers
   - `ssl_ciphers`: Specifies the allowed ciphers for SSL/TLS connections

5. In the location block, we added additional proxy headers to ensure proper forwarding of HTTPS information:
   - `X-Forwarded-Proto`: Indicates the protocol (HTTP or HTTPS) used by the client
   - `X-Forwarded-For`: Preserves the client's IP address
   - `Host`: Ensures the correct host header is passed to the upstream servers
   - `X-Real-IP`: Sets the real IP address of the client

To implement this configuration, you need to:

1. Replace `/path/to/your/certificate.crt` with the actual path to your SSL certificate file.
2. Replace `/path/to/your/certificate.key` with the actual path to your SSL certificate key file.

Make sure you have obtained a valid SSL certificate for your domain before enabling HTTPS. You can use services like Let's Encrypt to obtain free SSL certificates.

After making these changes, restart your Nginx server to apply the new configuration.
