### PR TITLE
[Dev Intern AI PR] handle https in the nginx configuration

### DIFF
--- a/build_scripts/nginx.conf
+++ b/build_scripts/nginx.conf
@@ -7,10 +7,31 @@ upstream site {
 server {
     listen 80;
     server_name _ ;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name _ ;
+
+    ssl_certificate /path/to/your/fullchain.pem;
+    ssl_certificate_key /path/to/your/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
 
     location / {
         proxy_pass http://site/;
         proxy_redirect off;
         proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }


### PR DESCRIPTION
To handle HTTPS in the Nginx configuration, we need to modify the existing configuration to include SSL/TLS settings. Let's update the `nginx.conf` file to support both HTTP and HTTPS. 

Here's the approach:

1. We'll add a new server block for HTTPS (port 443).
2. We'll redirect HTTP traffic to HTTPS for better security.
3. We'll include SSL certificate and key configurations.
4. We'll add some security headers for HTTPS connections.

Here's the updated configuration:

```vim build_scripts/nginx.conf:**********
upstream site {
    server localhost:8000 fail_timeout=5 max_fails=3 ;
    server localhost:8001 fail_timeout=5 max_fails=3 ;
    server localhost:8002 fail_timeout=5 max_fails=3 ;
}

server {
    listen 80;
    server_name _ ;
    return 301 https://$host$request_uri;
}

server {
    listen 443 ssl;
    server_name _ ;

    ssl_certificate /path/to/your/fullchain.pem;
    ssl_certificate_key /path/to/your/privkey.pem;
    ssl_protocols TLSv1.2 TLSv1.3;
    ssl_prefer_server_ciphers on;
    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;

    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
    add_header X-Frame-Options DENY;
    add_header X-Content-Type-Options nosniff;
    add_header X-XSS-Protection "1; mode=block";

    location / {
        proxy_pass http://site/;
        proxy_redirect off;
        proxy_http_version 1.1;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }
}
```

This configuration does the following:

1. Keeps the existing upstream configuration.
2. The first server block (port 80) now redirects all HTTP traffic to HTTPS.
3. A new server block for HTTPS (port 443) is added with SSL/TLS configurations.
4. SSL certificate and key paths are specified (you need to replace `/path/to/your/fullchain.pem` and `/path/to/your/privkey.pem` with your actual certificate paths).
5. Modern and secure SSL protocols and ciphers are set.
6. Security headers are added to enhance protection against common web vulnerabilities.
7. The location block for proxying requests is updated to include additional headers for proper forwarding of client information.

Note that you'll need to obtain and install SSL certificates for your domain before this configuration will work. You can get free certificates from Let's Encrypt.

Also, make sure to replace the paths to the SSL certificate and key with the actual paths on your server.
