### PR TITLE
[Dev Intern AI PR] handle https in the nginx configuration; the configuration of the nginx server should handle HTTPs

### DIFF
--- a/build_scripts/nginx.conf
+++ b/build_scripts/nginx.conf
@@ -7,10 +7,27 @@ upstream site {
 server {
     listen 80;
     server_name _ ;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name _ ;
+
+    ssl_certificate /path/to/your/fullchain.pem;
+    ssl_certificate_key /path/to/your/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
 
     location / {
         proxy_pass http://site/;
         proxy_redirect off;
         proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }


### PR DESCRIPTION
Certainly. To handle HTTPS in the Nginx configuration, we need to modify the existing configuration to include HTTPS support. We'll need to add a new server block for HTTPS traffic, specify the SSL certificate and key locations, and redirect HTTP traffic to HTTPS. Here's how we can modify the `nginx.conf` file to achieve this:

1. The biggest obstacle is ensuring we have the correct SSL certificate and key files.
2. We need to decide whether to keep the HTTP server or redirect all traffic to HTTPS.
3. We'll opt for redirecting all HTTP traffic to HTTPS for better security.

Here's the modified Nginx configuration:

```vim build_scripts/nginx.conf:**********
upstream site {
    server localhost:8000 fail_timeout=5 max_fails=3 ;
    server localhost:8001 fail_timeout=5 max_fails=3 ;
    server localhost:8002 fail_timeout=5 max_fails=3 ;
}

server {
    listen 80;
    server_name _ ;
    return 301 https://$host$request_uri;
}

server {
    listen 443 ssl;
    server_name _ ;

    ssl_certificate /path/to/your/fullchain.pem;
    ssl_certificate_key /path/to/your/privkey.pem;

    ssl_protocols TLSv1.2 TLSv1.3;
    ssl_prefer_server_ciphers on;
    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;

    location / {
        proxy_pass http://site/;
        proxy_redirect off;
        proxy_http_version 1.1;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }
}
```

This configuration does the following:

1. Keeps the existing upstream block for load balancing.
2. Adds a new server block that listens on port 80 (HTTP) and redirects all traffic to HTTPS.
3. Creates a new server block for HTTPS traffic:
   - Listens on port 443 with SSL enabled.
   - Specifies the SSL certificate and key file locations (you need to replace `/path/to/your/fullchain.pem` and `/path/to/your/privkey.pem` with your actual certificate and key file paths).
   - Sets up secure SSL protocols and ciphers.
   - Configures the location block to proxy requests to the upstream servers, similar to the original configuration, but with additional headers for proper SSL handling.

To implement this change, you need to:

1. Replace the content of `build_scripts/nginx.conf` with the provided configuration.
2. Ensure you have valid SSL certificate and key files, and update the paths in the configuration accordingly.
3. Restart the Nginx service to apply the changes.

Note that you'll need to obtain and install a valid SSL certificate for your domain before this configuration will work properly. You can use a service like Let's Encrypt to obtain a free SSL certificate.
